### PR TITLE
Change uptime host to uptime.eggheads.org

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -463,7 +463,7 @@ enum {
 #define UPTIME_SIGTERM          5003
 #define UPTIME_SIGINT           5004
 
-#define UPTIMEHOST		"uptime.energymech.net"
+#define UPTIMEHOST		"uptime.eggheads.org"
 
 #ifdef __CYGWIN__
 #define UPTIME_BOTTYPE		UPTIME_WINMECH

--- a/src/global.h
+++ b/src/global.h
@@ -267,7 +267,7 @@ BEG uint32_t	uptimeip		MDEF((uint32_t)-1);
 BEG uint32_t	uptimecookie;
 BEG uint32_t	uptimeregnr		MDEF(0);
 BEG time_t	uptimelast		MDEF(0);
-BEG const char	*defaultuptimehost	MDEF("uptime.energymech.net");
+BEG const char	*defaultuptimehost	MDEF("uptime.eggheads.org");
 
 #endif /* UPTIME */
 


### PR DESCRIPTION
Hey there,

since the energymech.net domain is defunct, and uptime.energymech.net was an alias for uptime.eggheads.org before the domain expired, this PR changes the host directly to uptime.eggheads.org.

Our uptime contest is still alive @ https://www.eggheads.org/uptime and we would love to see EnergyMech back on there :)